### PR TITLE
[BugFix] Convert string to exception class

### DIFF
--- a/lib/datadog_notifier.rb
+++ b/lib/datadog_notifier.rb
@@ -1,8 +1,11 @@
+# frozen_string_literal: true
+
 require 'ddtrace'
 
 class DatadogNotifier
   def self.notify(exception, payload = {})
     root_span = find_root_span(Datadog::Tracing.active_span)
+    exception = DatadogNotifierException.new exception if exception.is_a?(String)
     root_span.set_error(exception)
     root_span.set_tag('custom_dd_notifier', true)
     root_span.set_tag('payload', payload.to_json) if payload.present?

--- a/lib/datadog_notifier_exception.rb
+++ b/lib/datadog_notifier_exception.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class DatadogNotifierException < StandardError
+end


### PR DESCRIPTION
When we pass exception as string to the notify method, then datadog does not collect it error to show in Error tracking dashboard.

Datadog expects exception as Exception class, where it can fetch message and  backtrace from that exception and show the same in Error tracking dashboard.

Reference - https://github.com/DataDog/dd-trace-rb/blob/9add3ebb5ed9d055682a5d1ce6772949c74f05a7/lib/datadog/tracing/metadata/errors.rb#L14