### PR TITLE
replace ddtrace with datadog for new ruby version [v1.1.0]

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Or install it yourself as:
 
 ### Dependency
 * [Datadog](https://github.com/DataDog/dd-trace-rb) must be integrated in the project before we use this gem
-
+* use version <=1.0.4 for ruby <3.4
 # Quick Use
 ## Send notification to datadog(Traces to add errors in Datadog)
 ```DatadogNotifier.notify(exception, payload_json)```

--- a/datadog_notifier.gemspec
+++ b/datadog_notifier.gemspec
@@ -10,12 +10,12 @@ Gem::Specification.new do |spec|
   spec.version       = DatadogNotifier::VERSION
   spec.authors       = ['Patterninc']
   spec.email         = ['amol.udage@pattern.com']
-  spec.summary       = 'Datadog notifier to send custom errors with ddtrace'
+  spec.summary       = 'Datadog notifier to send custom errors with datadog'
   spec.description   = 'Datadog notifier to send custom errors in Datadog error tracking dashboard'
   spec.homepage      = 'https://github.com/patterninc/datadog_notifier'
   spec.license       = 'MIT'
 
-  spec.add_dependency 'ddtrace', '>= 1.13.0'
+  spec.add_dependency 'datadog', '>= 2.0.0'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/datadog_notifier.gemspec
+++ b/datadog_notifier.gemspec
@@ -15,7 +15,11 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/patterninc/datadog_notifier'
   spec.license       = 'MIT'
 
-  spec.add_dependency 'datadog', '>= 2.0.0'
+  if RUBY_VERSION >= '3.4'
+    spec.add_dependency 'datadog', '>= 2.0.0'
+  else
+    spec.add_dependency 'ddtrace', '>= 1.13.0'
+  end
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/datadog_notifier.gemspec
+++ b/datadog_notifier.gemspec
@@ -15,7 +15,10 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/patterninc/datadog_notifier'
   spec.license       = 'MIT'
 
-  if RUBY_VERSION >= '3.4'
+  ruby_version = Gem::Version.new(RUBY_VERSION)
+  breaking_version = Gem::Version.new('3.4')
+  
+  if ruby_version >= breaking_version
     spec.add_dependency 'datadog', '>= 2.0.0'
   else
     spec.add_dependency 'ddtrace', '>= 1.13.0'

--- a/datadog_notifier.gemspec
+++ b/datadog_notifier.gemspec
@@ -2,7 +2,7 @@
 
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'datadog_notifier'
+# Don't require datadog_notifier here - it has dependencies that aren't installed yet during bundle install
 require 'datadog_notifier/version'
 
 Gem::Specification.new do |spec|

--- a/lib/datadog_notifier.rb
+++ b/lib/datadog_notifier.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
-require 'ddtrace'
+if RUBY_VERSION < '3.4'
+  require 'ddtrace'
+else
+  require 'datadog'
+end
 require 'datadog_notifier_exception'
 require 'datadog_notifier/version'
 


### PR DESCRIPTION
## PR Details
Clickup Link - https://app.clickup.com/t/2323726/DIST-18283

### Description 
As part of updating rails app to use ruby 3.4.6, we needed to change ddrace gem with datadog since ddtrace was only compatible with ruby < 3.4

This change requires to replace dependency in datadog notifier gem from ddtrace to datadog 
#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
  <!--- Ruby style guide https://github.com/rubocop/ruby-style-guide -->
  <!--- Go Style Guide https://github.com/uber-go/guide/blob/master/style.md -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

