### PR TITLE
Onboard datadog-notifier to Backstage

### DIFF
--- a/backstage.yaml
+++ b/backstage.yaml
@@ -1,0 +1,17 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: datadog-notifier
+  description: 'A Onboard an Existing Repo to Backstage created via Backstage'
+  annotations:
+    repo: patterninc/datadog_notifier
+  labels:
+    CostCenter: DATA
+    Environment: stage
+    Name: datadog-notifier
+    Owner: dev-data-acquisition
+    Department: DATA
+    CreatedBy: Backstage
+spec:
+  type: service
+  system: data


### PR DESCRIPTION
Adds a `backstage.yaml` catalog descriptor so this repo appears in
the Backstage catalog.

Opened automatically by the *Onboard an Existing Repo to Backstage*
scaffolder template.
